### PR TITLE
Fix __split for new empty range behavior

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -67,7 +67,7 @@ function __split(str, splitter, limit::Integer, keep_empty::Bool, strs::Vector)
     pos = 1
     lst = lastindex(str)
     res = find(First, splitter, str)
-    if res != 0:-1
+    if res !== 0:-1
         j, k = first(res), nextind(str, last(res))
         while 0 < j <= lst && length(strs) != limit - 1
             if pos < k
@@ -77,7 +77,7 @@ function __split(str, splitter, limit::Integer, keep_empty::Bool, strs::Vector)
             end
             (k <= j) && (k = nextind(str, j))
             res = find(Fwd, splitter, str, k)
-            res == 0:-1 && break
+            res === 0:-1 && break
             j, k = first(res), nextind(str, last(res))
         end
     end

--- a/test/search.jl
+++ b/test/search.jl
@@ -13,42 +13,42 @@ const u8map = [1, 4, 5, 7, 8, 9, 10, 11, 12, 13, 16, 17, 19, 20, 21, 22, 23, 24,
 function test2(dir, P, str, list)
     for (p, res) in list
         pat = P(p)
-        (r = fnd(dir, pat, str)) == res ||
+        (r = fnd(dir, pat, str)) === res ||
             println("fnd($dir, $(typeof(pat)):\"$pat\", $(typeof(str)):\"$str\") => $r != $res")
-        @test fnd(dir, pat, str) == res
+        @test fnd(dir, pat, str) === res
     end
 end
 
 function test3(dir, P, str, list)
     for (p, beg, res) in list
         pat = P(p)
-        (r = fnd(dir, pat, str, beg)) == res ||
+        (r = fnd(dir, pat, str, beg)) === res ||
             println("fnd($dir, $(typeof(pat)):\"$pat\", $(typeof(str)):\"$str\", $beg) => $r != $res")
-        @test fnd(dir, pat, str, beg) == res
+        @test fnd(dir, pat, str, beg) === res
     end
 end
 
 function test2ch(dir, C, str, list)
     for (p, res) in list
         pat = cvtchar(C, p)
-        (r = fnd(dir, pat, str)) == res ||
+        (r = fnd(dir, pat, str)) === res ||
             println("fnd($dir, $(typeof(p)):\"$pat\"), $(typeof(str)):\"$str\") => $r != $res")
-        (r = fnd(dir, ==(pat), str)) == res ||
+        (r = fnd(dir, ==(pat), str)) === res ||
             println("fnd($dir, ==($(typeof(pat)):\"$pat\"), $(typeof(str)):\"$str\") => $r != $res")
-        @test fnd(dir, pat, str) == res
-        @test fnd(dir, ==(pat), str) == res
+        @test fnd(dir, pat, str) === res
+        @test fnd(dir, ==(pat), str) === res
     end
 end
 
 function test3ch(dir, C, str, list)
     for (p, beg, res) in list
         pat = cvtchar(C, p)
-        (r = fnd(dir, pat, str, beg)) == res ||
+        (r = fnd(dir, pat, str, beg)) === res ||
             println("fnd($dir, $(typeof(pat)):'$pat', $(typeof(str)):\"$str\", $beg) => $r != $res")
-        (r = fnd(dir, ==(pat), str, beg)) == res ||
+        (r = fnd(dir, ==(pat), str, beg)) === res ||
             println("fnd($dir, ==($(typeof(pat)):'$pat'), $(typeof(str)):\"$str\", $beg) => $r != $res")
-        @test fnd(dir, pat, str, beg) == res
-        @test fnd(dir, ==(pat), str, beg) == res
+        @test fnd(dir, pat, str, beg) === res
+        @test fnd(dir, ==(pat), str, beg) === res
     end
 end
 
@@ -147,14 +147,14 @@ end
             @testset "find empty string,..." begin
                 i = 1
                 while i <= ncodeunits(str)
-                    @test fnd(Fwd, emptyP, str, i) == i:i-1
-                    @test fnd(Rev, emptyP, str, i) == i:i-1
+                    @test fnd(Fwd, emptyP, str, i) === i:i-1
+                    @test fnd(Rev, emptyP, str, i) === i:i-1
                     i = nextind(str, i)
                 end
             end
 
-            @test fnd(First, emptyP, emptyT) == 1:0
-            @test fnd(Last, emptyP, emptyT) == 1:0
+            @test fnd(First, emptyP, emptyT) === 1:0
+            @test fnd(Last, emptyP, emptyT) === 1:0
         end
     end
 end
@@ -232,8 +232,8 @@ end
             @testset "find empty string,..." begin
                 i = 1
                 while i <= ncodeunits(str)
-                    @test fnd(Fwd, empty, str, i) == i:i-1
-                    @test fnd(Rev, empty, str, i) == i:i-1
+                    @test fnd(Fwd, empty, str, i) === i:i-1
+                    @test fnd(Rev, empty, str, i) === i:i-1
                     i = nextind(str, i)
                 end
             end

--- a/test/substr.jl
+++ b/test/substr.jl
@@ -224,7 +224,7 @@ function teststr(T)
     # search and SubString (issue #5679)
     let str = T("Hello, world!"),
         u = SubString(str, 1, 5)
-        @test fnd(Last, T("World"), u) == 0:-1
+        @test fnd(Last, T("World"), u) === 0:-1
         @test fnd(Last, ==('z'), u) == 0
         @test fnd(Last, T("ll"), u) == 3:4
     end


### PR DESCRIPTION
Starting with Julia 1.5, empty ranges compare equal (i.e., `1:0 == 0:-1`). This PR modifies `__split` to account for that.