### PR TITLE
Fix bug of to_ascii constructor from vectors and pointers

### DIFF
--- a/src/legacy.jl
+++ b/src/legacy.jl
@@ -4,8 +4,8 @@
 
 # Renamed from ascii to to_ascii, to prevent issues with Base.ascii
 to_ascii(str) = convert(ASCIIStr, str)
-to_ascii(pnt::Ptr{UInt8}) = convert(ASCIIStr, unsafe_string(p))
-to_ascii(pnt::Ptr{UInt8}, len::Integer) = convert(ASCIIStr, unsafe_string(p, len))
+to_ascii(p::Ptr{UInt8}) = convert(ASCIIStr, unsafe_string(p))
+to_ascii(p::Ptr{UInt8}, len::Integer) = convert(ASCIIStr, unsafe_string(p, len))
 
 """
     utf8(s)

--- a/src/utf8.jl
+++ b/src/utf8.jl
@@ -157,7 +157,7 @@ is_ascii(str::SubString{<:Str{C}}) where {C<:Union{UTF8CSE,LatinCSE,Binary_CSEs,
 
 is_ascii(vec::Vector{T}) where {T<:CodeUnitTypes} =
     (cnt = sizeof(vec)) == 0 ? true :
-    @preserve str _check_mask_ul(pointer(vec), cnt, _ascii_mask(T))
+    @preserve vec _check_mask_ul(pointer(vec), cnt, _ascii_mask(T))
 
 is_ascii(str::Str{C}) where {C<:Union{UTF8_CSEs,LatinCSE,Binary_CSEs,UTF16CSE,UCS2CSE,
                                       Text2CSE,Text4CSE,UTF32CSE}} =

--- a/test/basic.jl
+++ b/test/basic.jl
@@ -16,6 +16,11 @@ end
 
 string_types = keys(compat_types)
 
+legacy_types = Dict(ASCIIStr => to_ascii,
+                    UTF8Str => utf8,
+                    UTF16Str => utf16,
+                    UTF32Str => utf32)
+
 ##  create type specific test strings
 test_strings_base = Dict()
 for T in AllCharTypes
@@ -25,6 +30,14 @@ end
 @testset "constructors" begin
     for (ST, type_list) in compat_types, CT in type_list, str in test_strings_base[CT]
         @eval @test convert($ST, $str) == $str
+    end
+end
+
+@testset "legacy constructors" begin
+    for (ST, constructor) in legacy_types, str in test_strings_base[ASCIIChr]
+        vec = Vector{codeunit(ST)}(codeunits(str))
+        @eval @test $constructor($vec) == $str
+        @eval @test $constructor(pointer($vec), $(length(vec))) == $str
     end
 end
 


### PR DESCRIPTION
Correct a few typos that prevents creation of ascii strings from vectors and pointers. E.g.:

```
julia> v = collect(codeunits("asdfghjkl\0"))
10-element Array{UInt8,1}:
 0x61
 0x73
 0x64
 0x66
 0x67
 0x68
 0x6a
 0x6b
 0x6c
 0x00

julia> to_ascii(v)
ERROR: UndefVarError: str not defined
Stacktrace:
 [1] isascii(::Array{UInt8,1}) at C:\Users\jessy\.julia\packages\StrBase\3wQxZ\src\utf8.jl:158
 [2] convert(::Type{ASCIIStr}, ::Array{UInt8,1}) at C:\Users\jessy\.julia\packages\StrBase\3wQxZ\src\ascii.jl:52
 [3] to_ascii(::Array{UInt8,1}) at C:\Users\jessy\.julia\packages\StrBase\3wQxZ\src\legacy.jl:6
 [4] top-level scope at REPL[109]:1

julia> ASCIIStr(v)
ERROR: UndefVarError: str not defined
Stacktrace:
 [1] isascii(::Array{UInt8,1}) at C:\Users\jessy\.julia\packages\StrBase\3wQxZ\src\utf8.jl:158
 [2] convert(::Type{ASCIIStr}, ::Array{UInt8,1}) at C:\Users\jessy\.julia\packages\StrBase\3wQxZ\src\ascii.jl:52
 [3] ASCIIStr(::Array{UInt8,1}) at C:\Users\jessy\.julia\packages\StrBase\3wQxZ\src\types.jl:55
 [4] top-level scope at REPL[110]:1

julia> to_ascii(pointer(v))
ERROR: UndefVarError: p not defined
Stacktrace:
 [1] to_ascii(::Ptr{UInt8}) at C:\Users\jessy\.julia\packages\StrBase\3wQxZ\src\legacy.jl:7
 [2] top-level scope at REPL[111]:1
```
